### PR TITLE
feat: add tip for arbitrary Feedback metadata

### DIFF
--- a/docs/godot/feedback.md
+++ b/docs/godot/feedback.md
@@ -42,5 +42,5 @@ func _on_pressed() -> void:
 ```
 
 :::tip
-If you'd like to attach additional metadata to the feedback (player props, game state, etc.), you could always append `feedback_comment` with said metadata, before giving it to the `send()` function.
+You can attach additional metadata (player props, game state, etc.) to feedback by appending it to the `feedback_comment` String before calling `send()`.
 :::

--- a/docs/godot/feedback.md
+++ b/docs/godot/feedback.md
@@ -40,3 +40,7 @@ func _on_pressed() -> void:
 	await Talo.feedback.send(internal_name, feedback_comment)
 	print("Feedback sent for %s: %s" % [internal_name, feedback_comment])
 ```
+
+:::tip
+If you'd like to attach additional metadata to the feedback (player props, game state, etc.), you could always append `feedback_comment` with said metadata, before giving it to the `send()` function.
+:::

--- a/docs/unity/feedback.md
+++ b/docs/unity/feedback.md
@@ -62,3 +62,7 @@ public class SendFeedback : MonoBehaviour
 	}
 }
 ```
+
+:::tip
+If you'd like to attach additional metadata to the feedback (player props, game state, etc.), you could always append `feedbackComment` with said metadata, before giving it to the `Send()` function.
+:::


### PR DESCRIPTION
> **Tip**
> If you'd like to attach additional metadata to the feedback (player props, game state, etc.), you could always append `feedback_comment` with said metadata, before giving it to the `send()` function.

Sorry about the merge commit. I'd suggest squashing the two.